### PR TITLE
feature/SOF-7957 TMP

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,7 +36,7 @@ pip list
 if [[ -n ${UPDATE_CONTENT} ]]; then
     mkdir -p ${TMP_DIR} && cd ${TMP_DIR} || exit 1
     REPO_NAME="api-examples"
-    BRANCH_NAME="main"
+    BRANCH_NAME="feature/SOF-7957"
 
     # Always clone fresh to avoid stale cached state
     rm -rf "${REPO_NAME}"


### PR DESCRIPTION
Temporary: point JupyterLite build at feature/SOF-7957 (dielectric tensor notebook) for a durable Netlify deploy-preview test URL. Not to be merged; kept open for reuse.