### PR TITLE
tmp: build from api-examples feature/SOF-7959 (HOMO/LUMO + Frequency NWChem)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,7 +36,7 @@ pip list
 if [[ -n ${UPDATE_CONTENT} ]]; then
     mkdir -p ${TMP_DIR} && cd ${TMP_DIR} || exit 1
     REPO_NAME="api-examples"
-    BRANCH_NAME="feature/SOF-7917"
+    BRANCH_NAME="feature/SOF-7959"
 
     # Always clone fresh to avoid stale cached state
     rm -rf "${REPO_NAME}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,7 +36,7 @@ pip list
 if [[ -n ${UPDATE_CONTENT} ]]; then
     mkdir -p ${TMP_DIR} && cd ${TMP_DIR} || exit 1
     REPO_NAME="api-examples"
-    BRANCH_NAME="main"
+    BRANCH_NAME="feature/SOF-7917"
 
     # Always clone fresh to avoid stale cached state
     rm -rf "${REPO_NAME}"


### PR DESCRIPTION
## Summary
- Points `build.sh`'s content clone at `api-examples` branch `feature/SOF-7959` (HOMO/LUMO + Frequency NWChem notebook) to get a dedicated Netlify deploy preview for local WA testing.

## Test plan
- [x] Verified locally: rebuilt JL from the api-examples SOF-7959 checkout, ran the `homo_lumo_frequency.feature` Cypress spec against local WA + local JL — passed (1/1).
- [ ] Confirm Netlify preview build succeeds and serves the same content.
- [ ] Re-point WA's `jupyterLite.originURL` at the preview and re-run the Cypress spec against it.