### PR TITLE
test: build against api-examples SOF-7961 (Materials Designer REPL)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,7 +36,7 @@ pip list
 if [[ -n ${UPDATE_CONTENT} ]]; then
     mkdir -p ${TMP_DIR} && cd ${TMP_DIR} || exit 1
     REPO_NAME="api-examples"
-    BRANCH_NAME="main"
+    BRANCH_NAME="feature/SOF-7961"
 
     # Always clone fresh to avoid stale cached state
     rm -rf "${REPO_NAME}"


### PR DESCRIPTION
## Summary
- Temporary: points the api-examples content/wheel build at `feature/SOF-7961` instead of `main`.
- Purpose: get a real Netlify preview build of JupyterLite with the unpublished `sync_materials` / `preamble.material` additions, to validate materials-designer#279's Python REPL against the real deploy pipeline before those land in api-examples `main` / PyPI.
- Revert `BRANCH_NAME` back to `main` before merging (or just close this PR once validated — not meant to merge as-is).

## Test plan
- [ ] Netlify preview builds successfully
- [ ] Point materials-designer's `VITE_JUPYTERLITE_DEVELOPMENT_URL` at the preview URL
- [ ] Run the notebook_healthcheck Cypress suite against it